### PR TITLE
Dev/radix sort

### DIFF
--- a/Sorting-Stick/include/Gameplay/Collection/StickCollectionController.h
+++ b/Sorting-Stick/include/Gameplay/Collection/StickCollectionController.h
@@ -36,6 +36,7 @@ namespace Gameplay
             float calculateStickHeight(int array_pos);
 
             void updateStickPosition();
+            void updateStickPosition(int i);
             void shuffleSticks();
             bool compareSticksByData(const Stick* a, const Stick* b) const;
 

--- a/Sorting-Stick/source/Gameplay/Collection/StickCollectionController.cpp
+++ b/Sorting-Stick/source/Gameplay/Collection/StickCollectionController.cpp
@@ -468,7 +468,7 @@ namespace Gameplay
 				}
 
 
-				//updateStickPosition();
+				
 
 				if (current_operation_delay != 0)
 				{
@@ -503,7 +503,7 @@ namespace Gameplay
 
 				count[digit]--;
 
-				//updateStickPosition();
+				
 			}
 
 			// Place elements back into the main array
@@ -524,7 +524,7 @@ namespace Gameplay
 				}
 
 			}
-			//updateStickPosition();
+			
 		}
 
 		void StickCollectionController::radixSort()

--- a/Sorting-Stick/source/Gameplay/Collection/StickCollectionController.cpp
+++ b/Sorting-Stick/source/Gameplay/Collection/StickCollectionController.cpp
@@ -98,6 +98,14 @@ namespace Gameplay
 				sticks[i]->stick_view->setPosition(sf::Vector2f(x_position, y_position));
 			}
 		}
+
+		void StickCollectionController::updateStickPosition(int i)
+		{
+			float x_position = (i * sticks[i]->stick_view->getSize().x) + ((i)*collection_model->elements_spacing);
+			float y_position = collection_model->element_y_position - sticks[i]->stick_view->getSize().y;
+
+			sticks[i]->stick_view->setPosition(sf::Vector2f(x_position, y_position));
+		}
 		
 		void StickCollectionController::processBubbleSort()
 		{
@@ -460,7 +468,7 @@ namespace Gameplay
 				}
 
 
-				updateStickPosition();
+				//updateStickPosition();
 
 				if (current_operation_delay != 0)
 				{
@@ -495,7 +503,7 @@ namespace Gameplay
 
 				count[digit]--;
 
-				updateStickPosition();
+				//updateStickPosition();
 			}
 
 			// Place elements back into the main array
@@ -508,7 +516,7 @@ namespace Gameplay
 					sticks[i]->stick_view->setFillColor(collection_model->placement_position_element_color);  // Final sorted color for this digit
 				}
 
-				updateStickPosition();
+				updateStickPosition(i);
 
 				if (current_operation_delay != 0)
 				{
@@ -516,6 +524,7 @@ namespace Gameplay
 				}
 
 			}
+			//updateStickPosition();
 		}
 
 		void StickCollectionController::radixSort()

--- a/Sorting-Stick/source/Gameplay/Collection/StickCollectionController.cpp
+++ b/Sorting-Stick/source/Gameplay/Collection/StickCollectionController.cpp
@@ -104,9 +104,17 @@ namespace Gameplay
 			SoundService* sound = Global::ServiceLocator::getInstance()->getSoundService();
 			for (int j = 0; j < sticks.size(); j++)
 			{
+				if (current_operation_delay == 0)
+				{
+					break;
+				}
 				bool swapped = false;  // To track if a swap was made
 				for (int i = 1; i < sticks.size() - j; i++)  // Reduce the range each pass
 				{
+					if (current_operation_delay == 0)
+					{
+						break;
+					}
 					number_of_array_access += 2;
 					number_of_comparisons++;
 					sound->playSound(SoundType::COMPARE_SFX);
@@ -133,7 +141,12 @@ namespace Gameplay
 					break;
 			}
 
-			setCompletedColor();
+
+			if (current_operation_delay != 0)
+			{
+				setCompletedColor();
+			}
+
 		}
 
 		void StickCollectionController::processInsertionSort()
@@ -142,6 +155,10 @@ namespace Gameplay
 
 			for (int i = 1; i < sticks.size(); ++i)
 			{
+				if (current_operation_delay == 0)
+				{
+					break;
+				}
 				int j = i - 1;
 				Stick* key = sticks[i];
 				number_of_array_access++; // Access for key stick
@@ -155,6 +172,10 @@ namespace Gameplay
 
 				while (j >= 0 && sticks[j]->data > key->data)
 				{
+					if (current_operation_delay == 0)
+					{
+						break;
+					}
 					number_of_comparisons++;
 					number_of_array_access++; // Access for comparing sticks[j]->data with key->data
 
@@ -178,7 +199,10 @@ namespace Gameplay
 				sticks[j + 1]->stick_view->setFillColor(collection_model->selected_element_color); // Placed key is green indicating it's sorted
 			}
 
-			setCompletedColor();
+			if (current_operation_delay != 0)
+			{
+				setCompletedColor();
+			}
 		}
 
 		void StickCollectionController::processSelectionSort()
@@ -186,11 +210,19 @@ namespace Gameplay
 			SoundService* sound = Global::ServiceLocator::getInstance()->getSoundService();
 			for (int i = 0; i < sticks.size() - 1; ++i)
 			{
+				if (current_operation_delay == 0)
+				{
+					break;
+				}
 				int min_index = i;
 				sticks[i]->stick_view->setFillColor(collection_model->selected_element_color);  // Mark the start of processing
 
 				for (int j = i + 1; j < sticks.size(); ++j)
 				{
+					if (current_operation_delay == 0)
+					{
+						break;
+					}
 					number_of_array_access += 2;
 					number_of_comparisons++;
 
@@ -217,10 +249,13 @@ namespace Gameplay
 				updateStickPosition();
 			}
 
-			// Ensure the last stick is also marked as sorted
-			sticks[sticks.size() - 1]->stick_view->setFillColor(collection_model->placement_position_element_color);
 
-			setCompletedColor();  // Optional if you want to re-mark everything, can be redundant
+			if (current_operation_delay != 0)
+			{
+				// Ensure the last stick is also marked as sorted
+				sticks[sticks.size() - 1]->stick_view->setFillColor(collection_model->placement_position_element_color);
+				setCompletedColor();
+			}
 		}
 
 		void StickCollectionController::merge(int left, int mid, int right)
@@ -232,8 +267,12 @@ namespace Gameplay
 
 			// Copy elements to the temporary array
 			for (int index = left; index <= right; ++index) {
+				if (current_operation_delay != 0)
+				{
+					sticks[index]->stick_view->setFillColor(collection_model->temporary_processing_color);
+
+				}
 				temp[k++] = sticks[index];
-				sticks[index]->stick_view->setFillColor(collection_model->temporary_processing_color);
 				updateStickPosition();
 			}
 
@@ -249,10 +288,20 @@ namespace Gameplay
 				else {
 					sticks[k] = temp[j++];
 				}
-				sound->playSound(SoundType::COMPARE_SFX);
-				sticks[k]->stick_view->setFillColor(collection_model->processing_element_color);
+
+				if (current_operation_delay != 0)
+				{
+					sound->playSound(SoundType::COMPARE_SFX);
+					sticks[k]->stick_view->setFillColor(collection_model->processing_element_color);
+				}
+
 				updateStickPosition();  // Immediate update after assignment
-				std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay));
+
+				if (current_operation_delay != 0)
+				{
+					std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay));
+				}
+
 				k++;
 			}
 
@@ -264,22 +313,37 @@ namespace Gameplay
 				else {
 					sticks[k] = temp[j++];
 				}
-				sound->playSound(SoundType::COMPARE_SFX);
-				sticks[k]->stick_view->setFillColor(collection_model->processing_element_color);
+
+				if (current_operation_delay != 0)
+				{
+					sound->playSound(SoundType::COMPARE_SFX);
+					sticks[k]->stick_view->setFillColor(collection_model->processing_element_color);
+				}
+
+
 				updateStickPosition();  // Immediate update
-				std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay));
+
+				if (current_operation_delay != 0)
+				{
+					std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay));
+				}
+
 				k++;
 			}
 		}
 
 		void StickCollectionController::mergeSort(int left, int right)
 		{
-			if (left >= right) return;
-			int mid = left + (right - left) / 2;
+			if (current_operation_delay != 0)
+			{
+				if (left >= right) return;
+				int mid = left + (right - left) / 2;
 
-			mergeSort(left, mid);
-			mergeSort(mid + 1, right);
-			merge(left, mid, right);
+				mergeSort(left, mid);
+				mergeSort(mid + 1, right);
+				merge(left, mid, right);
+			}
+
 		}
 
 		void StickCollectionController::processMergeSort()
@@ -288,6 +352,7 @@ namespace Gameplay
 
 			if (current_operation_delay != 0)
 			{
+
 				setCompletedColor(); //set all sticks green (dramatic effect)
 			}
 
@@ -302,6 +367,10 @@ namespace Gameplay
 
 			for (int j = left; j < right; ++j)
 			{
+				if (current_operation_delay == 0)
+				{
+					break;
+				}
 
 				sticks[j]->stick_view->setFillColor(collection_model->processing_element_color);
 				number_of_array_access += 2;
@@ -333,7 +402,8 @@ namespace Gameplay
 
 		void StickCollectionController::quickSort(int left, int right)
 		{
-			if (left < right)
+
+			if (current_operation_delay != 0)
 			{
 				int pivot_index = partition(left, right);
 
@@ -346,13 +416,23 @@ namespace Gameplay
 					updateStickPosition();
 				}
 			}
+
 		}
 
 		void StickCollectionController::processQuickSort()
 		{
-			quickSort(0, sticks.size() - 1);
+			if (current_operation_delay != 0)
+			{
+				quickSort(0, sticks.size() - 1);
+			}
 
-			setCompletedColor();
+
+			if (current_operation_delay != 0)
+			{
+
+				setCompletedColor();
+			}
+
 		}
 
 		void StickCollectionController::countSort(int exponent)
@@ -363,38 +443,78 @@ namespace Gameplay
 
 			// Process each element to count digits
 			for (int i = 0; i < sticks.size(); ++i) {
-				sound->playSound(SoundType::COMPARE_SFX);
+
+				if (current_operation_delay != 0)
+				{
+					sound->playSound(SoundType::COMPARE_SFX);
+				}
+
+
 				int digit = (sticks[i]->data / exponent) % 10;
 				count[digit]++;
-				number_of_array_access++;
-				sticks[i]->stick_view->setFillColor(collection_model->processing_element_color);
+
+				if (current_operation_delay != 0)
+				{
+					number_of_array_access++;
+					sticks[i]->stick_view->setFillColor(collection_model->processing_element_color);
+				}
+
+
 				updateStickPosition();
-				std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay / 2)); // Delay for visual processing
-				sticks[i]->stick_view->setFillColor(collection_model->element_color);  // Reset color after processing
+
+				if (current_operation_delay != 0)
+				{
+					std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay / 2)); // Delay for visual processing
+					sticks[i]->stick_view->setFillColor(collection_model->element_color);  // Reset color after processing
+				}
+
+
 			}
 
 			// Accumulate the count array
 			for (int i = 1; i < 10; ++i) {
+
+
 				count[i] += count[i - 1];
 			}
 
 			// Sorting based on the current digit
 			for (int i = sticks.size() - 1; i >= 0; --i) {
 
+
+
 				int digit = (sticks[i]->data / exponent) % 10;
 				output[count[digit] - 1] = sticks[i];
-				output[count[digit] - 1]->stick_view->setFillColor(collection_model->temporary_processing_color);
+
+				if (current_operation_delay != 0)
+				{
+					output[count[digit] - 1]->stick_view->setFillColor(collection_model->temporary_processing_color);
+					number_of_array_access++;
+				}
+
+
 				count[digit]--;
-				number_of_array_access++;
+
 				updateStickPosition();
 			}
 
 			// Place elements back into the main array
 			for (int i = 0; i < sticks.size(); ++i) {
+
+
 				sticks[i] = output[i];
-				sticks[i]->stick_view->setFillColor(collection_model->placement_position_element_color);  // Final sorted color for this digit
+				if (current_operation_delay != 0)
+				{
+					sticks[i]->stick_view->setFillColor(collection_model->placement_position_element_color);  // Final sorted color for this digit
+				}
+
 				updateStickPosition();
-				std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay)); // Delay to observe final sorting state
+
+				if (current_operation_delay != 0)
+				{
+					std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay)); // Delay to observe final sorting state
+				}
+
 			}
 		}
 
@@ -403,14 +523,32 @@ namespace Gameplay
 			int maxElement = INT_MIN;
 			const int size = sticks.size();
 
-			for (int i = 0; i < size; ++i) maxElement = std::max(sticks[i]->data, maxElement);
-			for (int exponent = 1; maxElement / exponent > 0; exponent *= 10) countSort(exponent);
+			for (int i = 0; i < size; ++i)
+			{
+
+				maxElement = std::max(sticks[i]->data, maxElement);
+			}
+
+			for (int exponent = 1; maxElement / exponent > 0; exponent *= 10)
+			{
+				if (current_operation_delay == 0)
+				{
+					break;
+				}
+
+				countSort(exponent);
+			}
 		}
 
 		void StickCollectionController::processRadixSort()
 		{
 			radixSort();
-			setCompletedColor();
+
+			if (current_operation_delay != 0)
+			{
+				setCompletedColor();
+			}
+
 		}
 
 
@@ -433,11 +571,10 @@ namespace Gameplay
 
 			}
 
-			if (color_delay != 0)
-			{
-				sound->playSound(SoundType::SCREAM);
-			}
-			
+
+			sound->playSound(SoundType::SCREAM);
+
+
 		}
 
 		void StickCollectionController::shuffleSticks()

--- a/Sorting-Stick/source/Gameplay/Collection/StickCollectionController.cpp
+++ b/Sorting-Stick/source/Gameplay/Collection/StickCollectionController.cpp
@@ -375,25 +375,31 @@ namespace Gameplay
 
 			for (int j = left; j < right; ++j)
 			{
-				if (current_operation_delay == 0)
-				{
-					break;
+				if (current_operation_delay != 0) {
+					sticks[j]->stick_view->setFillColor(collection_model->processing_element_color);
+					number_of_array_access += 2;
+					number_of_comparisons++;
 				}
 
-				sticks[j]->stick_view->setFillColor(collection_model->processing_element_color);
-				number_of_array_access += 2;
-				number_of_comparisons++;
 
 				if (sticks[j]->data < sticks[right]->data)
 				{
 					++i;
 					std::swap(sticks[i], sticks[j]);
-					number_of_array_access += 3;
-					sound->playSound(SoundType::COMPARE_SFX);
+
+					if (current_operation_delay != 0) {
+						number_of_array_access += 3;
+						sound->playSound(SoundType::COMPARE_SFX);
+					}
+
 
 
 					updateStickPosition();
-					std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay));
+
+					if (current_operation_delay != 0) {
+						std::this_thread::sleep_for(std::chrono::milliseconds(current_operation_delay));
+					}
+
 				}
 
 				// Reset the color of the processed element if it's not swapped
@@ -410,13 +416,13 @@ namespace Gameplay
 
 		void StickCollectionController::quickSort(int left, int right)
 		{
-
-			if (current_operation_delay != 0)
+			if (left < right)
 			{
 				int pivot_index = partition(left, right);
 
 				quickSort(left, pivot_index - 1);
 				quickSort(pivot_index + 1, right);
+
 
 				// Set all elements in this segment to green after sorting is done
 				for (int i = left; i <= right; i++) {
@@ -424,20 +430,14 @@ namespace Gameplay
 					updateStickPosition();
 				}
 			}
-
 		}
 
 		void StickCollectionController::processQuickSort()
 		{
-			if (current_operation_delay != 0)
-			{
-				quickSort(0, sticks.size() - 1);
-			}
-
+			quickSort(0, sticks.size() - 1);
 
 			if (current_operation_delay != 0)
 			{
-
 				setCompletedColor();
 			}
 


### PR DESCRIPTION
- Visualization update for radix sort -> only updating the position of a single stick during merging (overloaded the update stick function). The old way was glitchy.

- Only quick sort will still stall the program if main menu is clicked in the middle. The rest should exit properly. 
   - We can do this better but I for that I will need to re-init the sticks everytime the main menu button is clicked. 
   - The issue is that I cannot just stop the process right now in a recursion algorithm since that would mess up the stick data values. -> will need all sticks to be delete and reinitialized at this point.